### PR TITLE
Fix typo on home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@ layout: default
         <div class="row-fluid">
             <div class="col-md-6 col-md-offset-3">
                 Hawaii is a lightweight Linux-based operating system, a suite of software that makes your computer run.
-                It uses the Hawaii Shell desktop workspace. You can use the Hawai operating system to replace or to
+                It uses the Hawaii Shell desktop workspace. You can use the Hawaii operating system to replace or to
                 run alongside of other operating systems such as Microsoft Windows™ or Mac OS X™ although it's not
                 currently considered as stable as other operating systems, if you feel brave enough you can be an
                 early adopter and let us know of glitches and bugs and help us make a great product.


### PR DESCRIPTION
"Hawaii" was spelled "Hawai"
